### PR TITLE
Add Jest tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,41 +1,47 @@
 {
-    "name": "fp-backend",
-    "version": "1.0.0",
-    "description": "Backend for frontend application (ФП) interacting with Payment Gateway and Electronic Wallet",
-    "main": "dist/index.js",
-    "scripts": {
-        "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-        "build": "tsc",
-        "start": "node dist/index.js",
-        "lint": "eslint . --ext .ts"
-    },
-    "author": "Asset",
-    "license": "MIT",
-    "dependencies": {
-        "@types/form-data": "^2.2.1",
-        "axios": "^1.4.0",
-        "bcrypt": "^5.1.0",
-        "cors": "^2.8.5",
-        "dayjs": "^1.11.13",
-        "dotenv": "^16.3.1",
-        "express": "^4.18.2",
-        "form-data": "^4.0.3",
-        "joi": "^17.10.0",
-        "jsonwebtoken": "^9.0.0",
-        "multer": "^2.0.0"
-    },
-    "devDependencies": {
-        "@types/bcrypt": "^5.0.0",
-        "@types/cors": "^2.8.19",
-        "@types/express": "^4.17.17",
-        "@types/jsonwebtoken": "^9.0.2",
-        "@types/multer": "^1.4.7",
-        "@types/node": "^20.4.2",
-        "eslint": "^8.49.0",
-        "eslint-config-prettier": "^9.0.0",
-        "eslint-plugin-import": "^2.30.3",
-        "prettier": "^3.0.0",
-        "ts-node-dev": "^2.0.0",
-        "typescript": "^5.1.6"
-    }
+  "name": "fp-backend",
+  "version": "1.0.0",
+  "description": "Backend for frontend application (ФП) interacting with Payment Gateway and Electronic Wallet",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "eslint . --ext .ts",
+    "test": "jest"
+  },
+  "author": "Asset",
+  "license": "MIT",
+  "dependencies": {
+    "@types/form-data": "^2.2.1",
+    "axios": "^1.4.0",
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "dayjs": "^1.11.13",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "form-data": "^4.0.3",
+    "joi": "^17.10.0",
+    "jsonwebtoken": "^9.0.0",
+    "multer": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/bcrypt": "^5.0.0",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^4.17.17",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/multer": "^1.4.7",
+    "@types/node": "^20.4.2",
+    "eslint": "^8.49.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-import": "^2.30.3",
+    "prettier": "^3.0.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.1.6",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3",
+    "supertest": "^6.3.3",
+    "@types/supertest": "^2.0.12"
+  }
 }

--- a/backend/tests/authController.spec.ts
+++ b/backend/tests/authController.spec.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express from 'express';
+import bcrypt from 'bcrypt';
+
+// set env before importing config
+process.env.PORT = '3000';
+process.env.JWT_SECRET = 'secret';
+process.env.PAYMENT_GATEWAY_BASE_URL = 'http://pg';
+process.env.WALLET_BASE_URL = 'http://wallet';
+process.env.PAYMENT_GATEWAY_TOKEN = 'tokpg';
+process.env.WALLET_TOKEN = 'tokw';
+
+import { loginHandler } from '../src/controllers/authController';
+import { FileService } from '../src/services/fileService';
+
+jest.mock('../src/services/fileService');
+
+const app = express();
+app.use(express.json());
+app.post('/login', loginHandler);
+
+describe('POST /login', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns token for valid credentials', async () => {
+    const password = 'pass';
+    const hash = await bcrypt.hash(password, 1);
+    jest
+      .spyOn(FileService, 'getAllUsers')
+      .mockResolvedValue([`1;user;${hash};finance`]);
+
+    const res = await request(app)
+      .post('/login')
+      .send({ login: 'user', password });
+
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.user.login).toBe('user');
+  });
+
+  test('returns 401 for wrong password', async () => {
+    const hash = await bcrypt.hash('correct', 1);
+    jest
+      .spyOn(FileService, 'getAllUsers')
+      .mockResolvedValue([`1;user;${hash};finance`]);
+
+    const res = await request(app)
+      .post('/login')
+      .send({ login: 'user', password: 'wrong' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/utils.spec.ts
+++ b/backend/tests/utils.spec.ts
@@ -1,0 +1,15 @@
+import { generateId, getCurrentISODate } from '../src/utils/utils';
+
+describe('utils', () => {
+  test('generateId returns unique id', () => {
+    const id1 = generateId();
+    const id2 = generateId();
+    expect(id1).not.toEqual(id2);
+    expect(typeof id1).toBe('string');
+  });
+
+  test('getCurrentISODate returns ISO string', () => {
+    const iso = getCurrentISODate();
+    expect(iso).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest configuration for backend tests
- install Jest-related dev dependencies
- add unit tests for utility functions
- add integration tests for authentication controller

## Testing
- `cd backend && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6846ea3b3c50832c88889671fa8219e6