### PR TITLE
Fix login redirect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import ManagerPaymentsPage from "./pages/Manager/ManagerPayments";
 import FinanceRedemptionPage from "./pages/Finance/FinanceRedemption";
 import SupervisorApprovalsPage from "./pages/Supervisor/SupervisorApprovals";
 import ProtectedRoute from "./layouts/ProtectedRoute";
+import AppLayout from "./layouts/AppLayout";
 import { ToastContainer } from "react-toastify";
 
 const App: React.FC = () => {
@@ -18,7 +19,7 @@ const App: React.FC = () => {
           path="/"
           element={
             <ProtectedRoute>
-              <Dashboard />
+              <AppLayout />
             </ProtectedRoute>
           }
         >

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,19 +6,18 @@ import App from "./App";
 import store from "./store";
 import { AuthProvider } from "./contexts/AuthContext";
 import "react-toastify/dist/ReactToastify.css";
-import "./index.css"; // если нужно, можно подключить Tailwind или свои стили
+import "./index.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 ReactDOM.createRoot(rootElement).render(
-    <React.StrictMode>
-      <Provider store={store}>
+  <React.StrictMode>
+    <Provider store={store}>
       <AuthProvider>
-      <BrowserRouter>
+        <BrowserRouter>
           <App />
         </BrowserRouter>
-        </AuthProvider>
-      </Provider>
-    </React.StrictMode>
-  );
-  
+      </AuthProvider>
+    </Provider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -24,7 +24,7 @@ const LoginPage: React.FC = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = (location.state as any)?.from?.pathname ?? "/dashboard";
+  const from = (location.state as any)?.from?.pathname;
 
   const {
     register,
@@ -38,7 +38,23 @@ const LoginPage: React.FC = () => {
     try {
       const resp = await loginRequest(data.login, data.password);
       login(resp.token, resp.user);
-      navigate(from, { replace: true });
+      let target = from;
+      if (!target) {
+        switch (resp.user.role) {
+          case "manager":
+            target = "/manager/payments";
+            break;
+          case "finance":
+            target = "/finance/redemption";
+            break;
+          case "supervisor":
+            target = "/supervisor/approvals";
+            break;
+          default:
+            target = "/dashboard";
+        }
+      }
+      navigate(target, { replace: true });
       toast.success("Успешный вход");
     } catch (err: any) {
       toast.error(err.response?.data?.message ?? "Ошибка входа");


### PR DESCRIPTION
## Summary
- use `AppLayout` for protected routes
- redirect by role after login
- clean up main.tsx

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_6846e9e69d78832c88250b2e36e794de